### PR TITLE
Fix to support virtual directories/folders in IIS.

### DIFF
--- a/src/VisualStudio/Glimpse.Knockout/ClientScript.cs
+++ b/src/VisualStudio/Glimpse.Knockout/ClientScript.cs
@@ -7,7 +7,7 @@ namespace Glimpse.Knockout
         public ScriptOrder Order { get { return ScriptOrder.IncludeAfterClientInterfaceScript; } }
         public string GetUri(string version)
         {
-            return "/Scripts/glimpse-knockout.js";
+            return System.Web.VirtualPathUtility.ToAbsolute("~/Scripts/glimpse-knockout.js");
         }
     }
 }


### PR DESCRIPTION
This is to fix 404 load errors of "/Scripts/glimpse-knockout.js" when a project is using a virtual sub directory in IIS as its base path.
